### PR TITLE
Category attribute for drill group

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,27 @@
 c
+@dg.category_ids
+c
+a[0]
+a = params[:drill_group][:category_ids].split(", ")
+params[:drill_group][:category_ids].split(", ")
+catf.split(", ")
+catf
+catf = params[:drill_group][:category_ids]
+cat
+cat = params[:drill_group][:category_ids]
+params[:drill_group][:category_ids]
+params[:drill_group].category_ids
+params[:drill_group]
+params["name"]
+params[:name]
+drill_group[:name]
+params[drill_group]
+params[:category_ids]
+params[:controller]
+params[:category_ids]
+params[category_ids]
+params
+c
 categories
 c
 params[:term]

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 
 .env
 Procfile
+
+.byebug_history
+
+track.txt

--- a/app/controllers/drill_groups_controller.rb
+++ b/app/controllers/drill_groups_controller.rb
@@ -11,6 +11,12 @@ class DrillGroupsController < ApplicationController
     redirect_to drill_groups_path, alert: "Access denied." and return unless current_user.admin?
     @dg = DrillGroup.new dg_params
     @dg.user = current_user
+    category_names = params[:drill_group][:category_ids].split(", ")
+    category_ids = []
+    category_names.each do |category|
+      category_ids.push(Category.find_by_name(category).id)
+    end
+    @dg.category_ids = category_ids
     if @dg.save
       redirect_to drill_group_path(@dg)
     else


### PR DESCRIPTION
ruby logic implemented!

Able to:
Add categorizations to a drill_group at drill_group creation
access drill_groups from categories (logic present, not used in application yet)